### PR TITLE
Add loadbalancer to license file because X-Forwared-Host is set

### DIFF
--- a/docker-ivy-cluster/license/cluster-tests.lic
+++ b/docker-ivy-cluster/license/cluster-tests.lic
@@ -1,21 +1,21 @@
 [Begin Licence]
 #Licence for AxonIvy Axon Ivy Engine (Enterprise Edition)
-#Thu Nov 02 09:04:06 CET 2023
+#Tue Apr 16 11:39:00 CEST 2024
 licence.keyversion=axonivy/11000
-licence.number=XLSEE-18B8-F0F9-BE9J
+licence.number=XLSEE-18EE-6462-3A0V
 licence.type=Enterprise Edition
-licence.valid.from=2023-11-02
+licence.valid.from=2024-04-16
 licence.valid.until=2025-11-05
 licencee.individual=reto.weiss@axonivy.com
 licencee.organisation=Axon Ivy AG
 product.name=Axon Ivy Engine
 product.type=Server
-public.urls=ivy1,ivy2,ivy3,ivy4
+public.urls=ivy1,ivy2,ivy3,ivy4,loadbalancer
 server.elements.limit=0
 server.nodes.limit=10
 server.sessions.limit=0
 server.users.limit=0
 [End Licence]
 [Begin Signature]
-MCwCFDUKtdgi05n/skHk4xbC/YLM9aZCAhR0eOfcXhKlx2YNXZtwgR530DmEBg==
+MCwCFB5cUF+IEBw8zQ8kjOm9wvK+21RrAhQQie3hG7iGRitHyyqYFgt5iGCCyA==
 [End Signature]


### PR DESCRIPTION
The used reverse proxy is setting X-Forwared-Host properly. Before we didn't respect it. Now we respect it. To prevent licensing issues we need to define the hostname of the loadbalancer in the license file. Maybe we could now remove all ivy1, ivy2. and so. But maybe some tests are accessing these ivy engines directly.